### PR TITLE
Convertions and wtf interface

### DIFF
--- a/console.py
+++ b/console.py
@@ -60,15 +60,17 @@ try:
                 if second == 'x':  (second, havesec) = ('0', False)
                 hour = (int(hour) % 12) + (0 if cmd == '!am' else 12)
                 havedate = True
-                if _date is None:
-                    havedate = False
-                    _date = '01.01.13'
-                (month, day, year) = _date.split('.') ## Yepp, this is how Jupiter Broadcasting writes dates numerically
-                year = int(year)
-                if year < 1000:
-                    year += 2000
                 os.environ['TZ'] = 'US/Pacific'
                 time.tzset()
+                if _date is None:
+                    havedate = False
+                    _date = time.localtime()
+                    year, month, day = _date.tm_year, _date.tm_mon, _date.tm_mday
+                else:
+                    (month, day, year) = _date.split('.') ## Yepp, this is how Jupiter Broadcasting writes dates numerically
+                year, _day = int(year), day
+                if year < 1000:
+                    year += 2000
                 (month, day, minute, second) = [int(x) for x in (month, day, minute, second)]
                 _time = time.mktime((year, month, day, hour, minute, second, 0, 0, -1))
                 _time = time.gmtime(_time)
@@ -81,7 +83,7 @@ try:
                 else:
                     if (hour == 0) and (minute == 0) and (second == 0) and (day == 2):
                         (hour, day) = (24, 1)
-                    print('%02d:%02d%s %sUTC' % (hour, minute, (':%02d' % second) if havesec else '', '' if day == 1 else 'next day '))
+                    print('%02d:%02d%s %sUTC' % (hour, minute, (':%02d' % second) if havesec else '', '' if day == _day else 'next day '))
             elif cmd == '!wtf':
                 # this requires the package wtf
                 Popen(['wtf'] + line.split(' '), stderr = sys.stdout)


### PR DESCRIPTION
I do not know Ruby and I cannot manage to install this package,
so I implemented the commands I would like as a standalone
program in Python.

!oz, !lb (and !lbs), !inch, !ft, !yard, !mile, !length and !°F
offers converts from that their names implies to a unit
in the metric system that is must corresponding to the
unit at the from-side of the convertion. !length converts
a length of a person expressed in feets and inches to
centimeters.

!am and !pm converts time optionally with a date to
from US/Pacific to UTC. !am and !pm only excepts
12-hour clocks and !am and !pm is used for specifying
that the time is before midday and after midday respectively.
If no date is specified 24:00 is prefered over 00:00 in the
output, which is in 24-hours.

The commands uses American formats as input, however
comma is not used for group of 3 separation, but rather
as a decminal put just as a dot.
The output is formated with comma as decimal point,
minus (not hyphen) for negative values, blanks space
for group separation. Time is formated HH:MM and HH:MM:SS
and dates are formatted yyyy-(mm)mmm-dd (so that cannot
be misinterpreted, the month is printed both numerically
and with three letters.)

!wtf uses the command `wtf` (requires the package wtf)
and is used just like `wtf` (but with a bang) and translates
abbreviations to words that you can understand.
