### PR TITLE
Sometimes, there is no show title.

### DIFF
--- a/lib/cinch/plugins/schedule.rb
+++ b/lib/cinch/plugins/schedule.rb
@@ -52,8 +52,10 @@ module Cinch
           else
             m.reply "Next show is #{next_event.summary} in #{ChronicDuration.output(nearest_seconds_until, :format => :long)} (#{time_string} on #{date_string})"
           end
-        else
+        elsif show
           m.reply "No upcoming show found for #{show.title}"
+        else
+          m.reply "No upcoming show found"
         end
 
       end


### PR DESCRIPTION
If there are no upcoming events, and !next is called with no arguments, it would die on a nil error because it was trying to get a show title. If there is no show, now it will just give a generic message.
