### PR TITLE
YAML::ENGINE is dropped in 2.2.0+ completely

### DIFF
--- a/showbot_irc.rb
+++ b/showbot_irc.rb
@@ -5,7 +5,9 @@ require 'cinchize'
 
 
 # Required to parse the cinchize.yml file properly
-YAML::ENGINE.yamler = 'psych'
+if RUBY_VERSION < '1.9.3'
+  YAML::ENGINE.yamler = 'psych' 
+end
 
 Options = {
   :ontop => true,


### PR DESCRIPTION
Psych has been the default since 1.9.3, so lets only use this on versions before then and hope nothing else breaks. ;)