### PR TITLE
Feature: Live Mode!

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,5 @@ S3_BUCKET=your_info_here
 S3_PATH=your_info_here
 S3_KEEP=your_info_here
 
+# Live mode toggle
+LIVE_MODE=true

--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,16 @@ S3_KEEP=your_info_here
 
 # Live mode toggle
 LIVE_MODE=true
+
+############################################################
+# SOCKET_KEY_ID
+# Default: false, websocket cx will be ID'd by request.ip
+#
+# Experimental ID clients based on a theoretically unique session key
+# issued on websocket cx establishment.
+#
+# WARNING: Should only be used in development for debugging purposes
+# until the reliability of this token can be established!
+############################################################
+# SOCKET_KEY_ID=true
+############################################################

--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,5 @@ LIVE_MODE=true
 # WARNING: Should only be used in development for debugging purposes
 # until the reliability of this token can be established!
 ############################################################
-# SOCKET_KEY_ID=true
+# SOCKET_KEY_ID=false
 ############################################################

--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,6 @@ group :development do
   gem 'foreman'
   gem 'rb-fsevent'
   gem 'irbtools-more'
-  gem 'pry'
-  gem 'pry-remote'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'mail', '~> 2.5.0'
 
 # Web
 gem 'sinatra'
+gem 'sinatra-websocket'
 gem 'sinatra-reloader'
 gem 'thin'
 gem 'haml'
@@ -59,6 +60,8 @@ group :development do
   gem 'foreman'
   gem 'rb-fsevent'
   gem 'irbtools-more'
+  gem 'pry'
+  gem 'pry-remote'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,13 +228,6 @@ GEM
     os (0.9.6)
     paint (1.0.0)
     polyglot (0.3.5)
-    pry (0.10.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    pry-remote (0.1.8)
-      pry (~> 0.9)
-      slop (~> 3.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -286,7 +279,6 @@ GEM
       em-websocket (~> 0.3.6)
       eventmachine
       thin (>= 1.3.1, < 2.0.0)
-    slop (3.6.0)
     spoon (0.0.4)
       ffi
     stopwords (0.2)
@@ -361,8 +353,6 @@ DEPENDENCIES
   irbtools-more
   mail (~> 2.5.0)
   net-ssh (>= 2.3.0, <= 2.5.2)
-  pry
-  pry-remote
   rack-test
   rake
   rb-fsevent

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
     dotenv (2.0.2)
     eat (0.1.8)
       httpclient
+    em-websocket (0.3.8)
+      addressable (>= 2.1.1)
+      eventmachine (>= 0.12.9)
     equalizer (0.0.11)
     eventmachine (1.0.7)
     every_day_irb (2.0.0)
@@ -225,6 +228,13 @@ GEM
     os (0.9.6)
     paint (1.0.0)
     polyglot (0.3.5)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -272,6 +282,11 @@ GEM
       tilt (>= 1.3, < 3)
     sinatra-reloader (1.0)
       sinatra-contrib
+    sinatra-websocket (0.3.1)
+      em-websocket (~> 0.3.6)
+      eventmachine
+      thin (>= 1.3.1, < 2.0.0)
+    slop (3.6.0)
     spoon (0.0.4)
       ffi
     stopwords (0.2)
@@ -346,6 +361,8 @@ DEPENDENCIES
   irbtools-more
   mail (~> 2.5.0)
   net-ssh (>= 2.3.0, <= 2.5.2)
+  pry
+  pry-remote
   rack-test
   rake
   rb-fsevent
@@ -353,6 +370,7 @@ DEPENDENCIES
   sass
   sinatra
   sinatra-reloader
+  sinatra-websocket
   stopwords (= 0.2)
   therubyracer
   thin
@@ -362,4 +380,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.10.3
+   1.11.2

--- a/cinchize.yml.example
+++ b/cinchize.yml.example
@@ -1,4 +1,12 @@
 ---
+test_hosts: &test_hosts
+  Live_Url: "localhost:5000/live"
+  Sinatra_Url: "http://localhost:5000"
+
+live_hosts: &live_hosts
+  Live_Url: "example.com/live"
+  Sinatra_Url: "http://www.example.com"
+
 # Plugins used for all configs
 plugins: &plugins
   plugins:
@@ -44,6 +52,13 @@ plugins: &plugins
     class: "Cinch::Plugins::StickyNick"
   -
     class: "Cinch::Plugins::Suggestions"
+    options:
+      live_titles:
+        enabled: true
+        test_hosts:
+          <<: *test_hosts
+        live_hosts:
+          <<: *live_hosts
   -
     class: "Cinch::Plugins::Twitter"
     options:
@@ -78,8 +93,7 @@ servers:
     shared:
       Bot_Nick: "botname"
       Backup_Bot_Nick: "botname-backup"
-      Live_Url: "localhost:5000/live"
-      Sinatra_Url: "http://localhost:5000"
+      <<: *test_hosts
   network_live:
     <<: *network_base
     nick: botname
@@ -88,5 +102,4 @@ servers:
     shared:
       Bot_Nick: "botname"
       Backup_Bot_Nick: "botname-backup"
-      Live_Url: "example.com/live"
-      Sinatra_Url: "http://www.example.com"
+      <<: *live_hosts

--- a/environment.rb
+++ b/environment.rb
@@ -20,7 +20,7 @@ configure do
   I18n.config.enforce_available_locales = true
   I18n.config.default_locale = ENV['SHOWBOT_LOCALE']
   I18n.config.locale = I18n.config.default_locale
-  
+
   # load models
   Dir.glob("#{File.dirname(__FILE__)}/lib/models/*.rb").sort.each { |lib| require lib }
 

--- a/lib/cinch/plugins/suggestions.rb
+++ b/lib/cinch/plugins/suggestions.rb
@@ -4,6 +4,8 @@ module Cinch
   module Plugins
     class Suggestions
       include Cinch::Plugin
+      require 'net/http'
+      require 'uri'
 
       match /suggest\s+(.*)/i,  :method => :command_suggest       # !suggest Great Title Here
 
@@ -31,6 +33,15 @@ module Cinch
 
           if new_suggestion.saved?
             m.user.send "Added title suggestion \"#{new_suggestion.title}\""
+
+            # Notify web server of new suggestion if enabled
+            if config.has_key?('live_titles') and config['live_titles']['enabled']
+              hosts_key = ARGV[0] == 'network_test' ? 'test_hosts' : 'live_hosts'
+              sinatra_root = config['live_titles'][hosts_key]['Sinatra_Url']
+              new_title_trigger_uri =
+                URI.parse("#{sinatra_root}/new_title_trigger?id=#{new_suggestion.id}")
+              Net::HTTP.get_response(new_title_trigger_uri)
+            end
           else
             new_suggestion.errors.each do |e|
               m.user.send e.first

--- a/public/css/showbot.css
+++ b/public/css/showbot.css
@@ -90,6 +90,23 @@ body {
     -ms-transform: rotate(-90deg);
     -o-transform: rotate(-90deg);
     transform: rotate(-90deg); }
+#header button.live-mode-toggle {
+  display: inline-block;
+  border-radius: 4px;
+  margin: 30px 0 0 5px;
+  /* Gotta make room for the lhs heart! */
+  color: #FFF;
+  border: none;
+  font: inherit;
+  cursor: pointer; }
+#header button.live-mode-toggle.live-is-on {
+  background-color: #990808; }
+#header button.live-mode-toggle.live-is-on:hover {
+  background-color: #8C0707; }
+#header button.live-mode-toggle.live-is-off {
+  background-color: #41BA53; }
+#header button.live-mode-toggle.live-is-off:hover {
+  background-color: #1CBA33; }
 
 nav {
   float: right;

--- a/public/css/showbot.css
+++ b/public/css/showbot.css
@@ -24,7 +24,7 @@ body {
 #header h1.logo {
   margin-bottom: 0; }
   #header h1.logo .heart {
-    color: #1b89ff;
+    color: #1B89FF;
     float: left;
     position: relative;
     opacity: 0;
@@ -81,7 +81,7 @@ body {
     -o-transition-delay: 0;
     transition-delay: 0; }
     #header h1.logo a:hover {
-      color: #1b89ff; }
+      color: #1B89FF; }
   #header h1.logo:hover .heart {
     opacity: 1;
     left: 0px;
@@ -291,6 +291,9 @@ ul.segmented_controls {
   background: url(/images/expand_arrow_sprite.png) no-repeat 0 0;
   text-align: right; }
 
+tr.cluster-top td.title {
+  cursor: pointer; }
+
 .expanded-arrow {
   background-position: 0 -19px; }
 
@@ -392,7 +395,7 @@ table.sortable .headerSortUp:after {
     font-size: 0.8em;
     width: 120px;
     font-weight: bold;
-    color: #b3b3b3;
+    color: #B3B3B3;
     color: rgba(0, 0, 0, 0.35);
     text-shadow: 0px 1px 0px #fff;
     text-shadow: 0px 1px 0px rgba(255, 255, 255, 0.9); }
@@ -447,7 +450,7 @@ table.sortable .headerSortUp:after {
     width: 14px;
     padding-top: 7px;
     font-weight: bold;
-    color: #b3b3b3;
+    color: #B3B3B3;
     color: rgba(0, 0, 0, 0.35);
     text-shadow: 0px 1px 0px #fff;
     text-shadow: 0px 1px 0px rgba(255, 255, 255, 0.9); }
@@ -457,94 +460,70 @@ table.sortable .headerSortUp:after {
     background-position: 0 0;
     bottom: 0;
     left: 0; }
-
   10% {
     left: 3px; }
-
   20% {
     left: -3px; }
-
   30% {
     left: 3px; }
-
   39% {
     background-position: 0 0; }
-
   40% {
     left: 3px;
     background-position: 0 -22px; }
-
   50% {
     left: 0;
     bottom: 0; }
-
   100% {
     bottom: 30px;
     left: 0;
     background-position: 0 -22px; } }
-
 @-moz-keyframes launch_arrow {
   0% {
     background-position: 0 0;
     bottom: 0;
     left: 0; }
-
   10% {
     left: 3px; }
-
   20% {
     left: -3px; }
-
   30% {
     left: 3px; }
-
   39% {
     background-position: 0 0; }
-
   40% {
     left: 3px;
     background-position: 0 -22px; }
-
   50% {
     left: 0;
     bottom: 0; }
-
   100% {
     bottom: 30px;
     left: 0;
     background-position: 0 -22px; } }
-
 @keyframes launch_arrow {
   0% {
     background-position: 0 0;
     bottom: 0;
     left: 0; }
-
   10% {
     left: 3px; }
-
   20% {
     left: -3px; }
-
   30% {
     left: 3px; }
-
   39% {
     background-position: 0 0; }
-
   40% {
     left: 3px;
     background-position: 0 -22px; }
-
   50% {
     left: 0;
     bottom: 0; }
-
   100% {
     bottom: 30px;
     left: 0;
     background-position: 0 -22px; } }
-
 .vote_arrow {
   display: inline-block;
   width: 14px;
@@ -718,7 +697,7 @@ li.link {
     bottom: -4px;
     font-size: 0.8em;
     font-weight: bold;
-    color: #b3b3b3;
+    color: #B3B3B3;
     color: rgba(0, 0, 0, 0.35);
     text-shadow: 0px 1px 0px #fff;
     text-shadow: 0px 1px 0px rgba(255, 255, 255, 0.9); }
@@ -727,7 +706,7 @@ li.link {
     text-align: right;
     font-size: 1em;
     font-weight: bold;
-    color: #b3b3b3;
+    color: #B3B3B3;
     color: rgba(0, 0, 0, 0.35);
     text-shadow: 0px 1px 0px #fff;
     text-shadow: 0px 1px 0px rgba(255, 255, 255, 0.9); }
@@ -753,7 +732,7 @@ li.link {
   font-weight: bold;
   text-align: center;
   font-weight: bold;
-  color: #b3b3b3;
+  color: #B3B3B3;
   color: rgba(0, 0, 0, 0.35);
   text-shadow: 0px 1px 0px #fff;
   text-shadow: 0px 1px 0px rgba(255, 255, 255, 0.9); }
@@ -763,11 +742,11 @@ li.link {
   clear: both;
   padding-top: 20px;
   width: 100%;
-  -webkit-box-shadow: inset 0 20px 20px -20px black;
-  -moz-box-shadow: inset 0 20px 20px -20px black;
-  -ms-box-shadow: inset 0 20px 20px -20px black;
-  -o-box-shadow: inset 0 20px 20px -20px black;
-  box-shadow: inset 0 20px 20px -20px black;
+  -webkit-box-shadow: inset 0 20px 20px -20px #000000;
+  -moz-box-shadow: inset 0 20px 20px -20px #000000;
+  -ms-box-shadow: inset 0 20px 20px -20px #000000;
+  -o-box-shadow: inset 0 20px 20px -20px #000000;
+  box-shadow: inset 0 20px 20px -20px #000000;
   font-size: 0.9em;
   text-shadow: 0px 1px 3px #000;
   text-shadow: 0px 1px 3px rgba(0, 0, 0, 0.8);
@@ -820,3 +799,5 @@ li.link {
   color: #999999;
   font-size: 0.4em;
   margin-top: 100px; }
+
+/*# sourceMappingURL=showbot.css.map */

--- a/public/js/jquery.parsehtml.js
+++ b/public/js/jquery.parsehtml.js
@@ -1,0 +1,48 @@
+(function () {
+    var rsingleTag;
+
+    if (typeof jQuery !== 'undefined' && !jQuery.parseHTML) {
+        /*!
+         * Copyright 2005, 2014 jQuery Foundation, Inc. and other contributors
+         * Released under the MIT license
+         * http://jquery.org/license
+         *
+         */
+
+        rsingleTag = /^<(\w+)\s*\/?>(?:<\/\1>|)$/;
+
+
+        // data: string of html
+        // context (optional): If specified, the fragment will be created in this context,
+        // defaults to document
+        // keepScripts (optional): If true, will include scripts passed in the html string
+        jQuery.parseHTML = function (data, context, keepScripts) {
+            if (!data || typeof data !== "string") {
+                return null;
+            }
+            if (typeof context === "boolean") {
+                keepScripts = context;
+                context = false;
+            }
+            context = context || document;
+
+            var parsed = rsingleTag.exec(data),
+                scripts = !keepScripts && [];
+
+            // Single tag
+            if (parsed) {
+                return [context.createElement(parsed[1])];
+            }
+
+            parsed = jQuery.buildFragment([data], [context], scripts);
+
+            if (scripts && scripts.length) {
+                jQuery(scripts).remove();
+            }
+
+            return jQuery.merge([], parsed.fragment.childNodes);
+        };
+
+        return jQuery.parseHTML;
+    }
+})();

--- a/sass/showbot.scss
+++ b/sass/showbot.scss
@@ -365,6 +365,10 @@ ul.segmented_controls {
   text-align: right;
 }
 
+tr.cluster-top td.title {
+  cursor: pointer;
+}
+
 .expanded-arrow {
   background-position: 0 -19px;
 }

--- a/showbot_web.rb
+++ b/showbot_web.rb
@@ -87,6 +87,7 @@ class ShowbotWeb < Sinatra::Base
       cluster_top = suggestion.top_of_cluster? # figure out if top before adding new vote
       suggestion.vote_up(request.ip)
       response = {
+        suggestion_id: suggestion.id,
         votes: suggestion.votes.count.to_s,
         cluster_top: cluster_top,
         cluster_id: suggestion.cluster_id,

--- a/showbot_web.rb
+++ b/showbot_web.rb
@@ -318,7 +318,6 @@ class ShowbotWeb < Sinatra::Base
   end
 
   def cluster_struct_for_suggestion(suggestion, request)
-        #.select{|sg| sg.id != suggestion.id }
     if suggestion.in_cluster?
       suggestion.cluster.suggestions
         .map do |sg|
@@ -381,22 +380,6 @@ class ShowbotWeb < Sinatra::Base
           settings.open_sockets.delete(socket_key)
         end
 
-        ########################################
-        # NOTE: No real need for the server to
-        # accept incomming socket messages. Upvotes
-        # continue to be delivered by standard AJAX
-        # and we'll just broadcast to hosts we're
-        # aware of that the event occurred.
-        ########################################
-        #ws.onmessage do |msg|
-          # Multicast
-          #EM.next_tick do
-            #settings.open_sockets.each do |k,v|
-              #if k == request.ip then next else v.send(msg.to_json) end
-            #end
-          #end
-        #end
-        ########################################
       end
     end
   end

--- a/showbot_web.rb
+++ b/showbot_web.rb
@@ -23,6 +23,7 @@ class ShowbotWeb < Sinatra::Base
     set :public_folder, "#{File.dirname(__FILE__)}/public"
     set :views, "#{File.dirname(__FILE__)}/views"
     set :shows, Shows.new { SHOWS_JSON }
+    set :live_mode_enabled, ENV['LIVE_MODE'] == "true"
   end
 
   configure(:production, :development) do

--- a/showbot_web.rb
+++ b/showbot_web.rb
@@ -7,7 +7,6 @@ require 'coffee_script'
 require 'sinatra' unless defined?(Sinatra)
 require 'sinatra/reloader' if development?
 require 'sinatra-websocket'
-require 'pry-remote'
 
 require 'json'
 

--- a/views/coffeescripts/showbot.coffee
+++ b/views/coffeescripts/showbot.coffee
@@ -21,28 +21,6 @@ jQuery(document).ready(->
   connect_to_socket()
 )
 
-refresh_timeago = ->
-  $("abbr.timeago").timeago().show().timeago().tipsy(
-    gravity: 'w'
-    fade: true
-  )
-
-force_resort = ($table)->
-  ############################################################
-  # HACK: We need to explicitly trigger a sort based on its current
-  # state, but doing so immediately after calling an update results
-  # in a race condition that can corrupt the sort of the table.
-  # Sitting it behind a 10ms delay allows update to finish before
-  # executing the sort, but this is obviously not ideal.
-  #
-  # Proper way to handle this:
-  # update.then(sortFn) via `onUpdate` event, which afaik, does not
-  # exist and needs to be hacked in to tablesorter.
-  ############################################################
-  $table.trigger('update')
-  sortFn = -> $table.trigger('sorton', [$table[0].config.sortList])
-  setTimeout(sortFn, 10) # Queue sort
-
 # Extract text from cells that aren't normal
 #
 # Returns a String of text that represents the cell for sorting purposes.
@@ -93,21 +71,43 @@ setup_voting = ->
     )
   )
 
-add_title_to_table = (msg) ->
-  tbody_sel =
-    ".suggestions_table[data-show-slug='" + msg.show_slug + "'] tbody"
-  $tbody = $(tbody_sel)
-  if $tbody.length == 0
-    # Expect to fail to find the table if this is the first tile.
-    # Page reload should render out the table and the title that
-    # triggered this update. Table should be found on subsequent
-    # updates
-    location.reload()
-  else
-    $tbody.append(msg.trl)
-    refresh_timeago()
-    increment_title_counts()
-    force_resort($tbody.closest('table'))
+connect_to_socket = ->
+  SOCKET_PATH = '/socket'
+  document.ws = new WebSocket('ws://' + window.location.host + SOCKET_PATH)
+  ws = document.ws
+  ws.onopen = -> console.log('Frontside ws cx open!')
+  ws.onclose = -> console.log('Frontside ws cx closed!')
+  ws.onmessage = (raw_msg) ->
+    view_mode = $('ul.segmented_controls > li.selected').attr('id')
+    msg = JSON.parse(raw_msg.data)
+    if !msg.action?
+      console.log('Got bad message, missing action')
+      return
+
+    dispatcher =
+      table:
+        upvote: update_votes
+        new_title: add_title_to_table
+      bubble:
+        upvote: -> console.log('NOT_YET_IMPLEMENTED: bubble_upvote')
+        new_title: add_title_to_bubble
+      clusters:
+        upvote: -> console.log('NOT_YET_IMPLEMENTED: clusters_upvote')
+        new_title: -> console.log('NOT_YET_IMPLEMENTED: clusters_new_title')
+
+    # Dispatch message to handlers
+    try
+      dispatcher[view_mode][msg.action](msg)
+    catch err
+      # Deliberately avoiding a rethrow here since a bad msg is not a critical failure
+      console.log('ERROR: Something went wrong during socket msg dispatch.')
+      console.log(err)
+      console.log(raw_msg)
+      console.log('Check view mode and make sure action is registered with dispatcher.')
+
+############################################################
+# Message Handlers
+############################################################
 
 update_votes = (response) ->
   if arguments.length == 3
@@ -137,6 +137,55 @@ update_votes = (response) ->
 
   force_resort($link.parents('table'))
 
+add_title_to_table = (msg) ->
+  tbody_sel =
+    ".suggestions_table[data-show-slug='" + msg.show_slug + "'] tbody"
+  $tbody = $(tbody_sel)
+  if $tbody.length == 0
+    # Expect to fail to find the table if this is the first tile.
+    # Page reload should render out the table and the title that
+    # triggered this update. Table should be found on subsequent
+    # updates
+    location.reload()
+  else
+    $tbody.append(msg.trl)
+    refresh_timeago()
+    increment_title_counts()
+    force_resort($tbody.closest('table'))
+
+add_title_to_bubble = (msg) ->
+  # !! TODO: IMPL NO OL FIND PAGE RELOAD
+  $ol = $("#titles ol[data-show-slug='"+ msg.show_slug + "']")
+
+  # Reclear list given newly prepended bubble
+  $ol.prepend(msg.bubble_live)
+  $ol.children('li').detach().each((idx, li) ->
+    if idx != 0 and idx % 3 == 0
+      $ol.append('<div class="clear"></div>')
+    $ol.append(li)
+  )
+  refresh_timeago()
+
+############################################################
+# Helpers
+############################################################
+
+force_resort = ($table)->
+  ############################################################
+  # HACK: We need to explicitly trigger a sort based on its current
+  # state, but doing so immediately after calling an update results
+  # in a race condition that can corrupt the sort of the table.
+  # Sitting it behind a 10ms delay allows update to finish before
+  # executing the sort, but this is obviously not ideal.
+  #
+  # Proper way to handle this:
+  # update.then(sortFn) via `onUpdate` event, which afaik, does not
+  # exist and needs to be hacked in to tablesorter.
+  ############################################################
+  $table.trigger('update')
+  sortFn = -> $table.trigger('sorton', [$table[0].config.sortList])
+  setTimeout(sortFn, 10) # Queue sort
+
 increment_title_counts = ->
   increment_title = ($el) ->
     title_count_rgx = /(\d+)( Title.*)$/
@@ -150,25 +199,9 @@ increment_title_counts = ->
   increment_title($('#content h2.subtitle'))
   increment_title($('#titles .suggestions_table .total'))
 
-connect_to_socket = ->
-  SOCKET_PATH = '/socket'
-  document.ws = new WebSocket('ws://' + window.location.host + SOCKET_PATH)
-  ws = document.ws
-  ws.onopen = -> console.log('Frontside ws cx open!')
-  ws.onclose = -> console.log('Frontside ws cx closed!')
-  ws.onmessage = (raw_msg) ->
-    msg = JSON.parse(raw_msg.data)
-    if !msg.action?
-      console.log('Got bad message, missing action')
-      return
+refresh_timeago = ->
+  $("abbr.timeago").timeago().show().timeago().tipsy(
+    gravity: 'w'
+    fade: true
+  )
 
-    # Dispatch action
-    if msg.action == 'upvote'
-      update_votes(msg)
-    else if msg.action == 'new_title'
-      add_title_to_table(msg)
-    else # Unknown action
-      # Swallow? Not much the user can do here, we're in a bad state.
-      # Could attempt to renegotiate cx, or reload page (nuclear option!)
-      # Not expecting to hit this branch.
-      console.log('Got bad message, unknown action')

--- a/views/coffeescripts/showbot.coffee
+++ b/views/coffeescripts/showbot.coffee
@@ -75,8 +75,8 @@ connect_to_socket = ->
   SOCKET_PATH = '/socket'
   document.ws = new WebSocket('ws://' + window.location.host + SOCKET_PATH)
   ws = document.ws
-  ws.onopen = -> console.log('Frontside ws cx open!')
-  ws.onclose = -> console.log('Frontside ws cx closed!')
+  ws.onopen = -> $('span.live-indicator').show()
+  ws.onclose = -> $('span.live-indicator').hide()
   ws.onmessage = (raw_msg) ->
     $seg_ctrl = $('ul.segmented_controls > li.selected')
     if $seg_ctrl.length == 0

--- a/views/coffeescripts/showbot.coffee
+++ b/views/coffeescripts/showbot.coffee
@@ -93,10 +93,21 @@ connect_to_socket = ->
 
     dispatcher =
       table:
-        upvote: update_votes
+        upvote: (msg)->
+          link_sel =
+            "tr[data-suggestion-id='" + msg.suggestion_id + "'] a.vote_up"
+          $link = $(link_sel)
+          $vote_count = $link.siblings('.vote_count').first()
+          update_votes(msg, $link, $vote_count)
+          force_resort($link.parents('table'))
         new_title: add_title_to_table
       bubble:
-        upvote: -> console.log('NOT_YET_IMPLEMENTED: bubble_upvote')
+        upvote: (msg) ->
+          link_sel =
+            "ol a[data-id='" + msg.suggestion_id + "'].vote_up"
+          $link = $(link_sel)
+          $vote_count = $link.siblings('.vote_count').first()
+          update_votes(msg, $link, $vote_count)
         new_title: add_title_to_bubble
       clusters:
         upvote: -> console.log('NOT_YET_IMPLEMENTED: clusters_upvote')
@@ -123,10 +134,6 @@ update_votes = (response) ->
     $vote_count = arguments[2]
   else
     # Live update branch
-    link_sel =
-      "tr[data-suggestion-id='" + response.suggestion_id + "'] a.vote_up"
-    $link = $(link_sel)
-    $vote_count = $link.siblings('.vote_count').first()
 
   vote_amount = parseInt(response.votes)
   if isNaN(vote_amount)
@@ -141,8 +148,6 @@ update_votes = (response) ->
       .siblings('#cluster-' + response.cluster_id)
       .children('.cluster-votes')
       .text(response.cluster_votes)
-
-  force_resort($link.parents('table'))
 
 add_title_to_table = (msg) ->
   tbody_sel =

--- a/views/coffeescripts/showbot.coffee
+++ b/views/coffeescripts/showbot.coffee
@@ -259,7 +259,7 @@ increment_title_counts = ->
 
   increment_title($('#content h2.subtitle'))
   if is_cluster_mode
-    update_cluster_count()
+    update_cluster_title_count()
   else
     increment_title($('#titles .suggestions_table .total'))
 
@@ -283,7 +283,7 @@ init_cluster_arrow_handler = ($titles)->
       $tr.attr('data-expansion-state', new_state)
     )
 
-update_cluster_count = ->
+update_cluster_title_count = ->
   group_count = $('tr.cluster-top, tr[data-sg-id]').length
   title_count = $('tbody tr').length
 

--- a/views/coffeescripts/showbot.coffee
+++ b/views/coffeescripts/showbot.coffee
@@ -149,6 +149,8 @@ connect_to_socket = ->
           else
             $('.suggestions_table tbody').append(msg.cluster.render)
 
+          increment_title_counts()
+
     # Dispatch message to handlers
     try
       dispatcher[view_mode][msg.action](msg)
@@ -234,6 +236,8 @@ force_resort = ($table)->
   setTimeout(sortFn, 10) # Queue sort
 
 increment_title_counts = ->
+  is_cluster_mode = $('.view_mode #clusters').hasClass('selected')
+
   increment_title = ($el) ->
     title_count_rgx = /(\d+)( Title.*)$/
 
@@ -244,7 +248,10 @@ increment_title_counts = ->
     )
 
   increment_title($('#content h2.subtitle'))
-  increment_title($('#titles .suggestions_table .total'))
+  if is_cluster_mode
+    update_cluster_count()
+  else
+    increment_title($('#titles .suggestions_table .total'))
 
 refresh_timeago = ->
   $("abbr.timeago").timeago().show().timeago().tipsy(
@@ -265,3 +272,15 @@ init_cluster_arrow_handler = ($titles)->
         new_state = 'closed'
       $tr.attr('data-expansion-state', new_state)
     )
+
+update_cluster_count = ->
+  group_count = $('tr.cluster-top, tr[data-sg-id]').length
+  title_count = $('tbody tr').length
+
+  count_str = if title_count == 1
+  then title_count + ' Title'
+  else title_count + ' Titles'
+
+  count_str += ' in ' + group_count + ' Group'
+
+  $('.suggestions_table .total').text(count_str)

--- a/views/coffeescripts/showbot.coffee
+++ b/views/coffeescripts/showbot.coffee
@@ -108,11 +108,9 @@ on_ws_message = (raw_msg) ->
       new_title: add_title_to_table
     bubble:
       upvote: (msg) ->
-        # TODO: Fix this logic if the link isn't available!
-        link_sel =
-          "ol a[data-id='" + msg.suggestion_id + "'].vote_up"
-        $link = $(link_sel)
-        $vote_count = $link.siblings('.vote_count').first()
+        vote_count_sel =
+          "ol .title_container[data-sg-id='" + msg.suggestion_id + "'] .vote_count"
+        $vote_count = $(vote_count_sel)
         update_votes(msg, $vote_count)
       new_title: add_title_to_bubble
     clusters:

--- a/views/coffeescripts/showbot.coffee
+++ b/views/coffeescripts/showbot.coffee
@@ -78,7 +78,14 @@ connect_to_socket = ->
   ws.onopen = -> console.log('Frontside ws cx open!')
   ws.onclose = -> console.log('Frontside ws cx closed!')
   ws.onmessage = (raw_msg) ->
-    view_mode = $('ul.segmented_controls > li.selected').attr('id')
+    $seg_ctrl = $('ul.segmented_controls > li.selected')
+    if $seg_ctrl.length == 0
+      # No titles for *any* show are available, reload the page
+      # so we get a first entry.
+      location.reload()
+    else
+      view_mode = $seg_ctrl.attr('id')
+
     msg = JSON.parse(raw_msg.data)
     if !msg.action?
       console.log('Got bad message, missing action')
@@ -142,10 +149,8 @@ add_title_to_table = (msg) ->
     ".suggestions_table[data-show-slug='" + msg.show_slug + "'] tbody"
   $tbody = $(tbody_sel)
   if $tbody.length == 0
-    # Expect to fail to find the table if this is the first tile.
-    # Page reload should render out the table and the title that
-    # triggered this update. Table should be found on subsequent
-    # updates
+    # Even if the seg controls are found, it's still possible this is
+    # the first suggestion for a new show, in which case force reload.
     location.reload()
   else
     $tbody.append(msg.trl)
@@ -154,8 +159,9 @@ add_title_to_table = (msg) ->
     force_resort($tbody.closest('table'))
 
 add_title_to_bubble = (msg) ->
-  # !! TODO: IMPL NO OL FIND PAGE RELOAD
   $ol = $("#titles ol[data-show-slug='"+ msg.show_slug + "']")
+  if $ol.length == 0
+    location.reload()
 
   # Reclear list given newly prepended bubble
   $ol.prepend(msg.bubble_live)

--- a/views/coffeescripts/showbot.coffee
+++ b/views/coffeescripts/showbot.coffee
@@ -234,6 +234,7 @@ add_title_to_cluster = (msg) ->
   else
     $('.suggestions_table tbody').append(msg.cluster.render)
 
+  refresh_timeago()
   increment_title_counts()
 
 ############################################################

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -21,10 +21,11 @@
           .banner DEVELOPMENT MODE
           .banner_push
       #header
-        %h1.logo
+        %h1.logo{:style => 'float: left'}
           %a{:href => '/'}=t('views.layout.header')
           -# display:none so the heart doesn't briefly show
           .heart{:style => 'display:none;'}=t('views.layout.heart')
+        %span.live-indicator{:style => "display: none; color: green; float: left; margin: 33px 0 0 -20px"} live!
         %nav
           %ul
             %li

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -25,7 +25,8 @@
           %a{:href => '/'}=t('views.layout.header')
           -# display:none so the heart doesn't briefly show
           .heart{:style => 'display:none;'}=t('views.layout.heart')
-        %span.live-indicator{:style => "display: none; color: green; float: left; margin: 33px 0 0 -20px"} live!
+        -if settings.live_mode_enabled
+          %button.live-mode-toggle.live-is-on Disable Live Mode
         %nav
           %ul
             %li
@@ -73,6 +74,13 @@
     %script{:type => "text/javascript", :src => "/js/d3.v3.min.js"}
     %script{:type => "text/javascript", :src => "/js/d3.layout.cloud.js"}
     %script{:type => "text/javascript", :src => "/js/word_cloud.js"}
+
+    :javascript
+      document.__jb = {};
+    -if settings.live_mode_enabled
+      :javascript
+        document.__jb['live_mode_enabled'] = true;
+
     / Main JS
     %script{:type => "text/javascript", :src  => "/js/showbot.js"}
     :javascript

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -69,6 +69,7 @@
     %script{:type => "text/javascript", :src  => "/js/jquery.timeago.js"}
     %script{:type => "text/javascript", :src  => "/js/jquery.tablesorter.min.js"}
     %script{:type => "text/javascript", :src => "/js/jquery.tipsy.js"}
+    %script{:type => "text/javascript", :src => "/js/jquery.parsehtml.js"}
     %script{:type => "text/javascript", :src => "/js/d3.v3.min.js"}
     %script{:type => "text/javascript", :src => "/js/d3.layout.cloud.js"}
     %script{:type => "text/javascript", :src => "/js/word_cloud.js"}

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -86,12 +86,5 @@
       })();
     :javascript
       $(function() {
-        $('tr.cluster-top').children('td.title')
-          .css("cursor","pointer")
-          .attr("title","Click to expand/collapse")
-          .click(function(){
-            $(this).parent().siblings('.child-'+this.parentElement.id).toggle();
-            $(this).find('.cluster-arrow').toggleClass('expanded-arrow')
-          });
         $('tr[class^="expand-child"]').hide().children('td');
       });

--- a/views/suggestion/_bubble.haml
+++ b/views/suggestion/_bubble.haml
@@ -1,6 +1,6 @@
 .hover.show=h Shows.find_show_title(suggestion.show) if suggestion.show
 .qstart “
-.title_container
+.title_container{"data-sg-id" => suggestion.id}
   .votes_container
     .votes=link_and_vote_count(suggestion, request.ip)
     .subtitle=t(:subtitle, :scope => [:views, :suggestion, :_bubble], :count => suggestion.votes_counter)

--- a/views/suggestion/_bubble_live.haml
+++ b/views/suggestion/_bubble_live.haml
@@ -1,7 +1,7 @@
 %li.bubble.grid_4
   .hover.show=h Shows.find_show_title(suggestion.show) if suggestion.show
   .qstart “
-  .title_container
+  .title_container{"data-sg-id" => suggestion.id}
     .votes_container
       .votes=link_and_vote_count(suggestion, request.ip)
       .subtitle=t(:subtitle, :scope => [:views, :suggestion, :_bubble], :count => suggestion.votes_counter)

--- a/views/suggestion/_bubble_live.haml
+++ b/views/suggestion/_bubble_live.haml
@@ -1,0 +1,13 @@
+%li.bubble.grid_4
+  .hover.show=h Shows.find_show_title(suggestion.show) if suggestion.show
+  .qstart “
+  .title_container
+    .votes_container
+      .votes=link_and_vote_count(suggestion, request.ip)
+      .subtitle=t(:subtitle, :scope => [:views, :suggestion, :_bubble], :count => suggestion.votes_counter)
+    .title=h suggestion.title
+  .qend ”
+  = timeago
+  .arrow_user
+    .user=h suggestion.user
+    %span.arrow

--- a/views/suggestion/_bubble_set.haml
+++ b/views/suggestion/_bubble_set.haml
@@ -2,7 +2,7 @@
   .clear
   = suggestion_set_hr(suggestion_set)
   - suggestions = suggestion_set.suggestions
-  %ol
+  %ol{"data-show-slug" => suggestion_set.slug}
     - col = 0
     - suggestions.each do |suggestion|
       %li.bubble.grid_4

--- a/views/suggestion/_cluster_set.haml
+++ b/views/suggestion/_cluster_set.haml
@@ -2,7 +2,7 @@
   - suggestions = suggestion_set.suggestions
   .clear
   = suggestion_set_hr(suggestion_set)
-  .suggestions_table
+  .suggestions_table{"data-show-slug" => suggestion_set.slug}
     - group_count = suggestions.map { |s| s.cluster_id }.uniq.reject { |s| s == nil }.count + suggestions.count { |s| s.cluster_id == nil }
     .total=t(:titles, :scope => [:views, :suggestion, :_cluster_set], :count => suggestions.count) + t(:groups, :scope => [:views, :suggestion, :_cluster_set], :count => group_count)
     %table.sortable

--- a/views/suggestion/_cluster_set.haml
+++ b/views/suggestion/_cluster_set.haml
@@ -16,11 +16,11 @@
         - suggestions.each do |suggestion|
           - if suggestion.in_cluster?
             - if suggestion.top_of_cluster?
-              %tr{:class => "cluster-top", :id => "cluster-#{suggestion.cluster_id}", "data-expansion-state" => "closed"}
+              %tr{:class => "cluster-top", :id => "cluster-#{suggestion.cluster_id}", "data-expansion-state" => "closed", "data-sg-id" => suggestion.id}
                 = haml :'suggestion/_cluster_table_row', :locals => {suggestion: suggestion, cluster_top: true}
               - suggestion.cluster.suggestions.each do |child_suggestion|
                 - if child_suggestion.id != suggestion.id
-                  %tr{:class => "expand-child child-cluster-#{child_suggestion.cluster_id}"}
+                  %tr{:class => "expand-child child-cluster-#{child_suggestion.cluster_id}", "data-sg-id" => child_suggestion.id}
                     = haml :'suggestion/_cluster_table_row', :locals => {suggestion: child_suggestion, cluster_top: false}
           - else
             %tr{"data-sg-id" => suggestion.id}

--- a/views/suggestion/_cluster_set.haml
+++ b/views/suggestion/_cluster_set.haml
@@ -23,5 +23,5 @@
                   %tr{:class => "expand-child child-cluster-#{child_suggestion.cluster_id}"}
                     = haml :'suggestion/_cluster_table_row', :locals => {suggestion: child_suggestion, cluster_top: false}
           - else
-            %tr
+            %tr{"data-sg-id" => suggestion.id}
               = haml :'suggestion/_cluster_table_row', :locals => {suggestion: suggestion, cluster_top: true}

--- a/views/suggestion/_cluster_set.haml
+++ b/views/suggestion/_cluster_set.haml
@@ -16,7 +16,7 @@
         - suggestions.each do |suggestion|
           - if suggestion.in_cluster?
             - if suggestion.top_of_cluster?
-              %tr{:class => "cluster-top", :id => "cluster-#{suggestion.cluster_id}"}
+              %tr{:class => "cluster-top", :id => "cluster-#{suggestion.cluster_id}", "data-expansion-state" => "closed"}
                 = haml :'suggestion/_cluster_table_row', :locals => {suggestion: suggestion, cluster_top: true}
               - suggestion.cluster.suggestions.each do |child_suggestion|
                 - if child_suggestion.id != suggestion.id

--- a/views/suggestion/_table_row_live.haml
+++ b/views/suggestion/_table_row_live.haml
@@ -1,4 +1,4 @@
-%tr
+%tr{"data-suggestion-id" => suggestion.id}
   %td.votes=link_and_vote_count(suggestion, request.ip)
   %td.title=h suggestion.title
   %td.user=h suggestion.user || t("views.suggestion._table_row.User")

--- a/views/suggestion/_table_row_live.haml
+++ b/views/suggestion/_table_row_live.haml
@@ -1,0 +1,6 @@
+%tr
+  %td.votes=link_and_vote_count(suggestion, request.ip)
+  %td.title=h suggestion.title
+  %td.user=h suggestion.user || t("views.suggestion._table_row.User")
+  %td.time
+    = timeago

--- a/views/suggestion/_table_set.haml
+++ b/views/suggestion/_table_set.haml
@@ -2,7 +2,7 @@
   - suggestions = suggestion_set.suggestions
   .clear
   = suggestion_set_hr(suggestion_set)
-  .suggestions_table
+  .suggestions_table{"data-show-slug" => suggestion_set.slug}
     .total="#{suggestions.count} Title#{suggestions.count == 1 ? '' : 's'}"
     %table.sortable.zebra-striped
       %thead

--- a/views/suggestion/_table_set.haml
+++ b/views/suggestion/_table_set.haml
@@ -13,5 +13,5 @@
           %th.header= t('views.suggestion._table_set.When')
       %tbody
         - suggestions.each do |suggestion|
-          %tr
+          %tr{"data-suggestion-id" => suggestion.id}
             = haml :'suggestion/_table_row', :locals => {suggestion: suggestion}

--- a/views/suggestion/live_cluster/_cluster.haml
+++ b/views/suggestion/live_cluster/_cluster.haml
@@ -1,7 +1,7 @@
 - cluster.each do |cstruct|
   - if cstruct[:belongs_to_cluster]
     - if cstruct[:is_top]
-      %tr{:class => "cluster-top", :id => "cluster-#{cstruct[:suggestion].cluster_id}"}
+      %tr{:class => "cluster-top", :id => "cluster-#{cstruct[:suggestion].cluster_id}", "data-expansion-state" => "closed"}
         = cstruct[:render]
     - else
       %tr{:class => "expand-child child-cluster-#{cstruct[:suggestion].cluster_id}", :style => "display: none"}

--- a/views/suggestion/live_cluster/_cluster.haml
+++ b/views/suggestion/live_cluster/_cluster.haml
@@ -7,6 +7,6 @@
       %tr{:class => "expand-child child-cluster-#{cstruct[:suggestion].cluster_id}", :style => "display: none"}
         = cstruct[:render]
   - else
-    %tr{"data-sg-id" => suggestion.id, :style => "border: 1px solid green"}
+    %tr{"data-sg-id" => suggestion.id}
       = cstruct[:render]
 

--- a/views/suggestion/live_cluster/_cluster.haml
+++ b/views/suggestion/live_cluster/_cluster.haml
@@ -1,0 +1,12 @@
+- cluster.each do |cstruct|
+  - if cstruct[:belongs_to_cluster]
+    - if cstruct[:is_top]
+      %tr{:class => "cluster-top", :id => "cluster-#{cstruct[:suggestion].cluster_id}"}
+        = cstruct[:render]
+    - else
+      %tr{:class => "expand-child child-cluster-#{cstruct[:suggestion].cluster_id}", :style => "display: none"}
+        = cstruct[:render]
+  - else
+    %tr{"data-sg-id" => suggestion.id, :style => "border: 1px solid green"}
+      = cstruct[:render]
+

--- a/views/suggestion/live_cluster/_cluster.haml
+++ b/views/suggestion/live_cluster/_cluster.haml
@@ -1,10 +1,10 @@
 - cluster.each do |cstruct|
   - if cstruct[:belongs_to_cluster]
     - if cstruct[:is_top]
-      %tr{:class => "cluster-top", :id => "cluster-#{cstruct[:suggestion].cluster_id}", "data-expansion-state" => "closed"}
+      %tr{:class => "cluster-top", :id => "cluster-#{cstruct[:suggestion].cluster_id}", "data-expansion-state" => "closed", "data-sg-id" => cstruct[:suggestion].id}
         = cstruct[:render]
     - else
-      %tr{:class => "expand-child child-cluster-#{cstruct[:suggestion].cluster_id}", :style => "display: none"}
+      %tr{:class => "expand-child child-cluster-#{cstruct[:suggestion].cluster_id}", :style => "display: none", "data-sg-id" => cstruct[:suggestion].id}
         = cstruct[:render]
   - else
     %tr{"data-sg-id" => suggestion.id}

--- a/views/suggestion/live_cluster/_cluster_table_row.haml
+++ b/views/suggestion/live_cluster/_cluster_table_row.haml
@@ -1,0 +1,12 @@
+- if suggestion.top_of_cluster?
+  %td.cluster-votes=suggestion.total_for_cluster
+- else
+  %td
+%td.votes=link_and_vote_count(suggestion, request.ip)
+%td.title
+  =h suggestion.title
+  - if suggestion.top_of_cluster? and suggestion.cluster_id
+    %span.cluster-arrow
+%td.user=h suggestion.user || t("views.suggestion._table_row.User")
+%td.time
+  = timeago


### PR DESCRIPTION
Goal of this PR is to provide a websocket based implementation for live client updates on
new title suggestions and upvotes. A few things to note:

* Patch is expecting some `cinchize.yml` changes, relevant file has to be updated in accordance
with the example file in the deployment environment

* `LIVE_MODE=[true|false]` in the `.env` file will enable or disable live mode. Defaults to
`true` in the example file, but if set to `false` or undefined, system will disable the feature
as if it doesn't exist.

* Socket bookkeeping is done on a `request.ip` basis by default. That means two clients cannot
be connected and receiving updates simultaneously -- the second connected client will force
disconnect the first. An experimental feature can be enabled via `SOCKET_KEY_ID=true`
in the `.env` file. This will attempt to bookkeep clients on a more granular, client specific basis.
It's experimental because I have no idea if the ID can be used reliably in this way! :tada:

---

There are probably some corner cases I've missed -- as can be seen in the update coffeescript,
the jquery can get a little low level and tedious. For something like this, a more **react**ive (heh) js framework would definitely improve the front end side of things, but we're basically talking about a rewrite there.

README updates incoming...