### PR TITLE
Feature/live quotes editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ################
 password.yml
 cinchize.yml
+quotes.yml
 
 # Logs, Databases & Cache #
 ###########################

--- a/cinchize.yml.example
+++ b/cinchize.yml.example
@@ -99,9 +99,6 @@ servers:
     shared:
       Bot_Nick: "botname"
       Backup_Bot_Nick: "botname-backup"
-      :allow_op_msgs: true # Allow chanops to administer certain plugins?
-      :owner: "" # Who owns the bot?
-      :server_has_nickserv: true # Does this server have nick registering methods available?
       <<: *test_hosts
   network_live:
     <<: *network_base

--- a/cinchize.yml.example
+++ b/cinchize.yml.example
@@ -93,6 +93,9 @@ servers:
     shared:
       Bot_Nick: "botname"
       Backup_Bot_Nick: "botname-backup"
+      :allow_op_msgs: true # Allow chanops to administer certain plugins?
+      :owner: "" # Who owns the bot?
+      :server_has_nickserv: true # Does this server have nick registering methods available?
       <<: *test_hosts
   network_live:
     <<: *network_base

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -45,13 +45,24 @@ module Cinch
       def add_quote(m, command)
         m.user.send("I need more arguments for that command.") and return if command.length < 3
         @quote_list.add(command[1], command[2..-1].join(" "))
+        save_to_disk
         m.reply("Quote added!")
       end
 
       def del_quote(m, command)
         m.user.send("I need more arguments for that command.") and return if command.length < 3
         @quote_list.del(command[1], command[2..-1].join(" "))
+        save_to_disk
         m.reply("Quote added!")
+      end
+
+      def save_to_disk
+        if !config[:quotes_file].nil?
+          quotes_path = File.join File.dirname(__FILE__), "../../../#{config[:quotes_file]}"
+          File.open(quotes_path, "w") {|file| file.write(@quote_list.quotes.to_yaml)}
+        else
+          User(shared[:owner]).send("Couldn't save quotes file; no location specified in config.")
+        end
       end
 
       def authed?(user)

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -15,7 +15,7 @@ module Cinch
       end
 
       def command_quote(m, name)
-        if name.start_with?("add ","del ", "alias ") || name == "dump"
+        if name.start_with?("add ","del ", "alias ")
           m.user.send("You have to be an admin to use that command.") and return unless authed? m.user
 
           command = name.split(" ")
@@ -24,8 +24,6 @@ module Cinch
             add_quote(m, command)
           when "del"
             del_quote(m, command)
-          when "dump"
-            debug @quote_list.quotes.to_s
           when "alias"
             m.user.send("Alias commands require four arguments.") and return if command.length != 4
             case command[1]

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -21,7 +21,7 @@ module Cinch
       end
 
       def command_quote(m, name)
-        if name.start_with?("add ","del ") || name == "dump"
+        if name.start_with?("add ","del ", "alias ") || name == "dump"
           m.user.send("You have to be an admin to use that command.") and return unless authed? m.user
 
           command = name.split(" ")
@@ -31,7 +31,15 @@ module Cinch
           when "del"
             del_quote(m, command)
           when "dump"
-            info @quote_list.quotes.to_s
+            debug @quote_list.quotes.to_s
+          when "alias"
+            m.user.send("Alias commands require four arguments.") and return if command.length != 4
+            case command[1]
+            when "add"
+              add_alias(m, command)
+            when "del"
+              del_alias(m, command)
+            end
           end
         else
           m.reply @quote_list.quote_for name
@@ -52,6 +60,18 @@ module Cinch
         @quote_list.del(command[1], command[2..-1].join(" "))
         save_to_disk
         m.reply("Quote removed!")
+      end
+
+      def add_alias(m, command)
+        @quote_list.add_alias(command[2], command[3])
+        save_to_disk
+        m.reply("Alias added!")
+      end
+
+      def del_alias(m, command)
+        @quote_list.del_alias(command[2], command[3])
+        save_to_disk
+        m.reply("Alias removed!")
       end
 
       def save_to_disk

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -21,7 +21,7 @@ module Cinch
       end
 
       def command_quote(m, name)
-        if name.include? " "
+        if name.start_with?("add ","del ") || name == "dump"
           m.user.send("You have to be an admin to use that command.") and return unless authed? m.user
 
           command = name.split(" ")
@@ -32,8 +32,6 @@ module Cinch
             del_quote(m, command)
           when "dump"
             info @quote_list.quotes.to_s
-          else
-            m.reply("#{shared[:Bot_Nick]} doesn't know that verb.")
           end
         else
           m.reply @quote_list.quote_for name

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -15,10 +15,21 @@ module Cinch
         else
           @quote_list = QuoteList.new(config)
         end
+        @owner_nick = shared[:owner]
+        @has_ns = shared[:server_has_nickserv]
+        @allow_op_msgs = shared[:allow_op_msgs]
       end
 
       def command_quote(m, name)
         m.reply @quote_list.quote_for name
+      end
+
+      def authed?(user)
+        if @allow_op_msgs
+          (user.nick == @owner_nick || user.oper?) && (user.authed? || !@has_ns)
+        else
+          user.nick == @owner_nick && (user.authed? || !@has_ns)
+        end
       end
     end
   end

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -21,7 +21,7 @@ module Cinch
       end
 
       def command_quote(m, name)
-        if name.includes? " "
+        if name.include? " "
           m.user.send("You have to be an admin to use that command.") and return unless authed? m.user
 
           command = name.split(" ")
@@ -30,6 +30,8 @@ module Cinch
             add_quote(m, command)
           when "del"
             del_quote(m, command)
+          when "dump"
+            info @quote_list.quotes.to_s
           else
             m.reply("#{shared[:Bot_Nick]} doesn't know that verb.")
           end
@@ -43,11 +45,13 @@ module Cinch
       def add_quote(m, command)
         m.user.send("I need more arguments for that command.") and return if command.length < 3
         @quote_list.add(command[1], command[2..-1].join(" "))
+        m.reply("Quote added!")
       end
 
       def del_quote(m, command)
         m.user.send("I need more arguments for that command.") and return if command.length < 3
         @quote_list.del(command[1], command[2..-1].join(" "))
+        m.reply("Quote added!")
       end
 
       def authed?(user)

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -53,7 +53,7 @@ module Cinch
         m.user.send("I need more arguments for that command.") and return if command.length < 3
         @quote_list.del(command[1], command[2..-1].join(" "))
         save_to_disk
-        m.reply("Quote added!")
+        m.reply("Quote removed!")
       end
 
       def save_to_disk

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -46,22 +46,22 @@ module Cinch
 
       private
 
-      def command_add_quote(m, name, quote)
+      def command_quote_add(m, name, quote)
         @quote_list.add(name, quote)
         m.reply("Quote added!")
       end
 
-      def command_del_quote(m, name, quote)
+      def command_quote_del(m, name, quote)
         @quote_list.del(name, quote)
         m.reply("Quote removed!")
       end
 
-      def command_add_alias(m, original, alias_name)
+      def command_alias_add(m, original, alias_name)
         @quote_list.add_alias(original, alias_name)
         m.reply("Alias added!")
       end
 
-      def command_del_alias(m, original, alias_name)
+      def command_alias_del(m, original, alias_name)
         @quote_list.del_alias(original, alias_name)
         m.reply("Alias removed!")
       end

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -21,7 +21,33 @@ module Cinch
       end
 
       def command_quote(m, name)
-        m.reply @quote_list.quote_for name
+        if name.includes? " "
+          m.user.send("You have to be an admin to use that command.") and return unless authed? m.user
+
+          command = name.split(" ")
+          case command.first
+          when "add"
+            add_quote(m, command)
+          when "del"
+            del_quote(m, command)
+          else
+            m.reply("#{shared[:Bot_Nick]} doesn't know that verb.")
+          end
+        else
+          m.reply @quote_list.quote_for name
+        end
+      end
+
+      private
+
+      def add_quote(m, command)
+        m.user.send("I need more arguments for that command.") and return if command.length < 3
+        @quote_list.add(command[1], command[2..-1].join(" "))
+      end
+
+      def del_quote(m, command)
+        m.user.send("I need more arguments for that command.") and return if command.length < 3
+        @quote_list.del(command[1], command[2..-1].join(" "))
       end
 
       def authed?(user)

--- a/lib/cinch/plugins/quotes.rb
+++ b/lib/cinch/plugins/quotes.rb
@@ -8,13 +8,7 @@ module Cinch
 
       def initialize(*args)
         super
-        if !config[:quotes_file].nil?
-          quotes_path = File.join File.dirname(__FILE__), "../../../#{config[:quotes_file]}"
-          quotes_yaml = YAML.load_file quotes_path
-          @quote_list = QuoteList.new quotes_yaml
-        else
-          @quote_list = QuoteList.new(config)
-        end
+        @quote_list = QuoteList.new(config)
         @owner_nick = shared[:owner]
         @has_ns = shared[:server_has_nickserv]
         @allow_op_msgs = shared[:allow_op_msgs]
@@ -51,36 +45,23 @@ module Cinch
       def add_quote(m, command)
         m.user.send("I need more arguments for that command.") and return if command.length < 3
         @quote_list.add(command[1], command[2..-1].join(" "))
-        save_to_disk
         m.reply("Quote added!")
       end
 
       def del_quote(m, command)
         m.user.send("I need more arguments for that command.") and return if command.length < 3
         @quote_list.del(command[1], command[2..-1].join(" "))
-        save_to_disk
         m.reply("Quote removed!")
       end
 
       def add_alias(m, command)
         @quote_list.add_alias(command[2], command[3])
-        save_to_disk
         m.reply("Alias added!")
       end
 
       def del_alias(m, command)
         @quote_list.del_alias(command[2], command[3])
-        save_to_disk
         m.reply("Alias removed!")
-      end
-
-      def save_to_disk
-        if !config[:quotes_file].nil?
-          quotes_path = File.join File.dirname(__FILE__), "../../../#{config[:quotes_file]}"
-          File.open(quotes_path, "w") {|file| file.write(@quote_list.quotes.to_yaml)}
-        else
-          User(shared[:owner]).send("Couldn't save quotes file; no location specified in config.")
-        end
       end
 
       def authed?(user)

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -2,7 +2,7 @@ class QuoteList
   def initialize(config)
     unless config[:quotes_file].nil?
       @quotes_path = File.join File.dirname(__FILE__), "../../../#{config[:quotes_file]}"
-      @quotes = YAML.load_file quotes_path
+      @quotes = YAML.load_file @quotes_path
       @can_save = true
     else
       warn "Quotes file was nil. QUOTE CHANGES WILL NOT BE SAVED!"

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -11,8 +11,7 @@ class QuoteList
   end
 
   def add(name, quote)
-    canonical_name = canonicalize name
-    return '' if !canonical_name
+    name.downcase!
     @quotes[canonical_name][:quotes] << quote
   end
 

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -9,6 +9,18 @@ class QuoteList
     @quotes[canonical_name][:quotes].sample
   end
 
+  def add(name, quote)
+    canonical_name = canonicalize name
+    return '' if !canonical_name
+    @quotes[canonical_name][:quotes] << quote
+  end
+
+  def del(name, quote)
+    canonical_name = canonicalize name
+    return '' if !canonical_name
+    @quotes[canonical_name][:quotes].delete(quote)
+  end
+
   private
 
   def canonicalize(name)

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -12,6 +12,7 @@ class QuoteList
 
   def add(name, quote)
     name.downcase!
+    @quotes[name] ||= {aliases:[], quotes:[]}
     @quotes[name][:quotes] << quote
   end
 

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -20,6 +20,7 @@ class QuoteList
     canonical_name = canonicalize name
     return '' if !canonical_name
     @quotes[canonical_name][:quotes].delete(quote)
+    @quotes.delete(canonical_name) if @quotes[canonical_name][:quotes].length == 0
   end
 
   private

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -12,7 +12,7 @@ class QuoteList
 
   def add(name, quote)
     name.downcase!
-    @quotes[canonical_name][:quotes] << quote
+    @quotes[name][:quotes] << quote
   end
 
   def del(name, quote)

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -1,4 +1,5 @@
 class QuoteList
+  attr_reader :quotes
   def initialize(quotes)
     @quotes = quotes
   end

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -1,7 +1,13 @@
 class QuoteList
-  attr_reader :quotes
-  def initialize(quotes)
-    @quotes = quotes
+  def initialize(config)
+    unless config[:quotes_file].nil?
+      @quotes_path = File.join File.dirname(__FILE__), "../../../#{config[:quotes_file]}"
+      @quotes = YAML.load_file quotes_path
+      @can_save = true
+    else
+      warn "Quotes file was nil. QUOTE CHANGES WILL NOT BE SAVED!"
+      @can_save = false
+    end
   end
 
   def quote_for(name)
@@ -15,6 +21,7 @@ class QuoteList
     @quotes[name] ||= {aliases:[], quotes:[]}
     if @quotes[name][:quotes].select {|q| q.downcase == quote.downcase} == []
       @quotes[name][:quotes] << quote
+      save_to_disk
     else
       ''
     end
@@ -25,18 +32,21 @@ class QuoteList
     return '' if !canonical_name
     @quotes[canonical_name][:quotes].delete(quote)
     @quotes.delete(canonical_name) if @quotes[canonical_name][:quotes].length == 0
+    save_to_disk
   end
 
   def add_alias(name, a)
     canonical_name = canonicalize name
     return '' if !canonical_name
     @quotes[canonical_name][:aliases] << a
+    save_to_disk
   end
 
   def del_alias(name, a)
     canonical_name = canonicalize name
     return '' if !canonical_name
     @quotes[canonical_name][:aliases].delete(a)
+    save_to_disk
   end
 
   private
@@ -57,5 +67,9 @@ class QuoteList
     Array(aliases).map(&:downcase).any? do |element|
       element.downcase == name
     end
+  end
+
+  def save_to_disk
+    File.open(@quotes_path, "w") {|file| file.write(@quotes.to_yaml)} if @can_save
   end
 end

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -1,7 +1,7 @@
 class QuoteList
   def initialize(config)
     unless config[:quotes_file].nil?
-      @quotes_path = File.join File.dirname(__FILE__), "../../../#{config[:quotes_file]}"
+      @quotes_path = File.join File.dirname(__FILE__), "../../#{config[:quotes_file]}"
       @quotes = YAML.load_file @quotes_path
       @can_save = true
     else

--- a/lib/models/quotelist.rb
+++ b/lib/models/quotelist.rb
@@ -13,7 +13,11 @@ class QuoteList
   def add(name, quote)
     name.downcase!
     @quotes[name] ||= {aliases:[], quotes:[]}
-    @quotes[name][:quotes] << quote
+    if @quotes[name][:quotes].select {|q| q.downcase == quote.downcase} == []
+      @quotes[name][:quotes] << quote
+    else
+      ''
+    end
   end
 
   def del(name, quote)
@@ -21,6 +25,18 @@ class QuoteList
     return '' if !canonical_name
     @quotes[canonical_name][:quotes].delete(quote)
     @quotes.delete(canonical_name) if @quotes[canonical_name][:quotes].length == 0
+  end
+
+  def add_alias(name, a)
+    canonical_name = canonicalize name
+    return '' if !canonical_name
+    @quotes[canonical_name][:aliases] << a
+  end
+
+  def del_alias(name, a)
+    canonical_name = canonicalize name
+    return '' if !canonical_name
+    @quotes[canonical_name][:aliases].delete(a)
   end
 
   private

--- a/quotes.yml.example
+++ b/quotes.yml.example
@@ -1,0 +1,24 @@
+8ball:
+  :aliases:
+    - 'eight_ball'
+  :quotes:
+    - "It is certain"
+    - "It is decidedly so"
+    - "Without a doubt"
+    - "Yes, definitely"
+    - "You may rely on it"
+    - "As I see it, yes"
+    - "Most likely"
+    - "Outlook good"
+    - "Yes"
+    - "Signs point to yes"
+    - "Reply hazy, try again"
+    - "Ask again later"
+    - "Better not tell you now"
+    - "Cannot predict now"
+    - "Concentrate and ask again"
+    - "Don't count on it"
+    - "My reply is no"
+    - "My sources say no"
+    - "Outlook not so good"
+    - "Very doubtful"


### PR DESCRIPTION
This pull request aims to add live editing to the quotes plugin. This enables the bot owner and, optionally, channel operators, to add quotes to the quote list, without manually editing `quotes.yml`.  
It also moves the file handling code into the data model, abstracting it away from the view.

If you don't want this as part of canonical Showbot, that's fine. I wrote it mostly for practice, since I only learned Ruby last Sunday.

-s0ph0s