### PR TITLE
Possibly resolves #42

### DIFF
--- a/environment.rb
+++ b/environment.rb
@@ -14,6 +14,7 @@ require 'sinatra' unless defined?(Sinatra)
 
 configure do
   Dotenv.load
+  LIVE_URL = ENV['DATA_JSON_URL']
   Dir[File.join(Dir.pwd, 'locales', '*.yml')].each {|file| I18n.load_path << file }
   # Make sure only available locales are used. This will be the default in the
   # future but we need this to silence a deprecation warning
@@ -47,4 +48,3 @@ configure :test do
   DataMapper.finalize
 end
 
-LIVE_URL = ENV['DATA_JSON_URL']

--- a/lib/models/show.rb
+++ b/lib/models/show.rb
@@ -8,7 +8,7 @@
 #   aliases: (array[string]) An array of aliases that can additionally match
 #     the show
 class Show
-  attr_reader :title, :url, :rss, :aliases
+  attr_reader :title, :url, :rss, :aliases, :limit
 
   # param json_hash: (hash) A hash of show data with the following keys:
   #   title: (string) The show's title
@@ -22,6 +22,7 @@ class Show
     @title = json_hash["title"]
     @url = json_hash["url"]
     @rss = json_hash["rss"]
+    @limit = json_hash.key?("limit") ? json_hash["limit"] : 40
     @aliases = (json_hash["aliases"] || []).map do |show_alias|
       show_alias.downcase
     end

--- a/lib/models/suggestion.rb
+++ b/lib/models/suggestion.rb
@@ -15,7 +15,7 @@ class Suggestion
   include DataMapper::Resource
 
   property :id,         Serial
-  property :title,      String,   :length => Shows.fetch_live_show.limit,
+  property :title,      String,   :length => Shows.fetch_live_show.nil? ? 40 : Shows.fetch_live_show.limit,
     :message => I18n.t('messages.models.suggestion')
   property :user,       String
   property :show,       String

--- a/lib/models/suggestion.rb
+++ b/lib/models/suggestion.rb
@@ -15,7 +15,7 @@ class Suggestion
   include DataMapper::Resource
 
   property :id,         Serial
-  property :title,      String,   :length => 40,
+  property :title,      String,   :length => Shows.fetch_live_show.limit,
     :message => I18n.t('messages.models.suggestion')
   property :user,       String
   property :show,       String


### PR DESCRIPTION
Possibly resolves #42.

shows.json can now contain a "limit" member that specifies a character limit for the specific show's title.

Changed hard limit in DataMapper class in suggestion.rb from 40 to the value of live show's limit. Not sure of workflow. May be a problem there is no live show in data.json?
Also bumped setting LIVE_URL to immediately after call to Dotenv.load, otherwise it gets set too late to
initialize the Suggestion class.