### PR TITLE
Silent mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,8 @@ LIVE_MODE=true
 # Digital Ocean Droplet Admin
 # DO_API_KEY=xxxxxxxxx
 
+SILENT_MODE=false
+
 ############################################################
 # SOCKET_KEY_ID
 # Default: false, websocket cx will be ID'd by request.ip

--- a/extensions.rb
+++ b/extensions.rb
@@ -11,3 +11,29 @@ class Cinch::User
     end
   end
 end
+
+class Cinch::Message
+  def reply(text)
+    if ENV[SILENT_MODE].downcase == 'true'
+      puts "%s: Reply to %s = %s" % [SILENT_MODE, user.nick, text]
+    else
+      text = text.to_s
+      if @channel && prefix
+        text = text.split("\n").map {|l| "#{user.nick}: #{l}"}.join("\n")
+      end
+      reply_target.send(text)
+    end
+  end
+end
+
+class Cinch::Message
+  def action_reply(text)
+    if ENV[SILENT_MODE].downcase == 'true'
+      puts "%s: Action reply to %s = %s" % [SILENT_MODE, user.nick, text]
+    else
+      text = text.to_s
+      reply_target.action(text)
+    end
+  end
+end
+

--- a/extensions.rb
+++ b/extensions.rb
@@ -1,0 +1,13 @@
+require 'cinchize'
+
+SILENT_MODE="SILENT_MODE"
+
+class Cinch::User
+  def send(text)
+    if ENV[SILENT_MODE].downcase == 'true'
+      puts "%s: Private message to %s = %s" % [SILENT_MODE, nick, text]
+    else
+      super text
+    end
+  end
+end

--- a/showbot_irc.rb
+++ b/showbot_irc.rb
@@ -2,6 +2,7 @@ require File.join(File.dirname(__FILE__), 'environment')
 
 require 'optparse'
 require 'cinchize'
+require './extensions.rb'
 require 'droplet_kit'
 require 'auth/admin_plugin'
 


### PR DESCRIPTION
Possibly resolves #64.

I've added a SILENT_MODE environment variable and included it in the example file.

Added extensions.rb with the monkey patches. Was able to just call super with Cinch::User since send() is from the Target base class.

reply() and action_reply() are actually members of Cinch::Message, so the patch overwrites them and I had to copy the implementation into the extension. This could be problematic if the implementation changes in the future. Is there possibly a better way or another way to patch the class without changing the API?

Output when in silent mode is in the format:
SILENT MODE: Type of message to [user nick] = [message that would have been sent]