### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+- 2.1
+script:
+- bundle exec rake test:test
+- bundle exec rake spec:unit
+- bundle exec rake spec:acceptance

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Stories in Ready](https://badge.waffle.io/rikai/Showbot.png?label=ready&title=Ready)](https://waffle.io/rikai/Showbot)
 # JBot
+[![Build Status](https://travis-ci.org/rikai/Showbot.svg?branch=master)](https://travis-ci.org/rikai/Showbot)
 
 A sweet IRC bot with a **web interface** for [Jupiter Broadcasting](http://www.jupiterbroadcasting.com/).
 Built on [cinch](https://github.com/cinchrb/cinch) and [sinatra](http://www.sinatrarb.com/). It is a fork/evolution of
@@ -20,7 +21,7 @@ follwing message once it is connected to an IRC network:
 
 ### Prerequisites
 
- * [RVM with Ruby 1.9.2 or Greater](https://rvm.io/)
+ * [RVM with Ruby 2.1.10 or greater](https://rvm.io/)
  * [Bundler](http://gembundler.com/)
  * Git (for pulling down source from Github, alternately download a tarball)
  * SQLite3 (for development)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Stories in Ready](https://badge.waffle.io/rikai/Showbot.png?label=ready&title=Ready)](https://waffle.io/rikai/Showbot)
-# JBot
 [![Build Status](https://travis-ci.org/rikai/Showbot.svg?branch=master)](https://travis-ci.org/rikai/Showbot)
+# JBot
 
 A sweet IRC bot with a **web interface** for [Jupiter Broadcasting](http://www.jupiterbroadcasting.com/).
 Built on [cinch](https://github.com/cinchrb/cinch) and [sinatra](http://www.sinatrarb.com/). It is a fork/evolution of

--- a/Rakefile
+++ b/Rakefile
@@ -104,3 +104,5 @@ namespace :api_key do
     end
   end
 end
+
+task :default => ["test:test", "spec:unit", "spec:acceptance"]


### PR DESCRIPTION
This gets us started on #45.

This skeleton travis.yml should provide us with a working build file for Travis.  I tested it using my forked repo and it appears to be working as expected.

You'll still need to enable the Travis API and flip the switch yourself since I don't have the keys to the kingdom. 😛